### PR TITLE
added nhoodReducedDim slot to milo object and updated function for plotting results 

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -17,7 +17,8 @@ setClass("Milo",
              nhoodDistances = "matrixORdgCMatrixORdsCMatrix", # this should be NA or a matrix
              nhoodCounts = "matrixORdgCMatrixORdsCMatrix", # this should be NA or a matrix
              nhoodIndex = "list", # used to store nhood indices
-             nhoodExpression = "matrixORdgCMatrixORdsCMatrix" # this should be NA or a matrix
+             nhoodExpression = "matrixORdgCMatrixORdsCMatrix", # this should be NA or a matrix
+             nhoodReducedDim = "list" # this should be a list
          ),
          prototype = list(
              graph = list(),
@@ -25,6 +26,7 @@ setClass("Milo",
              nhoodDistances = Matrix::Matrix(0L, sparse=TRUE),
              nhoodCounts = Matrix::Matrix(0L, sparse=TRUE),
              nhoodIndex = list(),
-             nhoodExpression = Matrix::Matrix(0L, sparse=TRUE)
+             nhoodExpression = Matrix::Matrix(0L, sparse=TRUE),
+             nhoodReducedDim = list()
          )
 )

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -39,3 +39,9 @@ setGeneric("nhoodExpression", function(x) standardGeneric("nhoodExpression"))
 
 #' @export
 setGeneric("nhoodExpression<-", function(x, value) standardGeneric("nhoodExpression<-"))
+
+#' @export
+setGeneric("nhoodReducedDim", function(x) standardGeneric("nhoodReducedDim"))
+
+#' @export
+setGeneric("nhoodReducedDim<-", function(x, value) standardGeneric("nhoodReducedDim<-"))

--- a/R/methods.R
+++ b/R/methods.R
@@ -84,6 +84,19 @@ setMethod("nhoodExpression<-", "Milo", function(x, value){
 })
 
 
+#' @export
+#' @describeIn Milo get nhoodReducedDim
+setMethod("nhoodReducedDim", "Milo", function(x) x@nhoodReducedDim)
+
+#' @export
+#' @describeIn Milo set nhoodReducedDim
+setMethod("nhoodReducedDim<-", "Milo", function(x, value){
+    x@nhoodReducedDim <- value
+    validObject(x)
+    x
+})
+
+
 #' @importFrom S4Vectors coolcat
 #' @importFrom methods callNextMethod
 .milo_show <- function(object) {
@@ -94,6 +107,7 @@ setMethod("nhoodExpression<-", "Milo", function(x, value){
     coolcat("graph names(%d): %s\n", names(object@graph))
     coolcat("nhoodIndex names(%d): %s\n", length(object@nhoodIndex))
     coolcat("nhoodExpression dimension(%d): %s\n", dim(object@nhoodExpression))
+    coolcat("nhoodReducedDim names(%d): %s\n", names(object@nhoodReducedDim))
 
     sink(file="/dev/null")
     gc()

--- a/R/plotNhoods.R
+++ b/R/plotNhoods.R
@@ -90,35 +90,42 @@ plotNhoodSizeHist <- function(milo, bins=50){
 #' @rdname plotMiloReducedDim
 #' @import ggplot2
 #' @importFrom dplyr left_join mutate arrange
-plotMiloReducedDim <- function(x, milo_results, reduced_dims="UMAP", filter_alpha=NULL, split_by=NULL,
+plotMiloReducedDim <- function(x, milo_results, nhood_reduced_dims="UMAP", filter_alpha=NULL, split_by=NULL,
                                pt_size=1.5, components=c(1,2)
 ){
+  ## Check for valid nhoodReducedDim object
+  # Should have nrows = no. of nhoods + no. of cells
+  if (!nhood_reduced_dims %in% names(nhoodReducedDim(x))){
+    stop(paste(nhood_reduced_dims, "is not the name of an embedding in nhoodReducedDims(x). Available reductions are:", paste((nhoodReducedDim(x)), collapse = ", ")))
+  } else if (nrow(nhoodReducedDim(x)[[nhood_reduced_dims]]) != ncol(x) + length(nhoods(x))) {
+    stop(paste(nhood_reduced_dims, "is not a valid nhoodReducedDims(x) object. The number of rows should match the sum of the number of cells and the number of neighbourhoods"))
+    }
+  
   ## Join test results and dimensionality reductions
-  if (reduced_dims %in% reducedDimNames(x)){
-    rdim_df <- data.frame(reducedDim(x, reduced_dims))[,components]
-  } else {
-    stop(paste(reduced_dims, "is not the name of a dimensionality reduction result in x. Available reductions are:", paste(reducedDimNames(x), collapse = ", ")))
-  }
+  rdim_df <- data.frame(nhoodReducedDim(x)[[nhood_reduced_dims]])[,components]
   colnames(rdim_df) <- c('X','Y')
-  rdim_df[,"nhIndex"] <- 1:nrow(rdim_df)
-  nhIndex <- unlist(nhoodIndex(x))
-  milo_results[,"nhIndex"] <- nhIndex
-  viz2_df  <- left_join(rdim_df, milo_results, by="nhIndex") 
+  
+  n_nhoods <- length(nhoods(x))
+  rdim_df[,"Nhood"] <- ifelse(1:nrow(rdim_df) %in% c(1:n_nhoods), c(1:n_nhoods), NA)
+  viz_df  <- left_join(rdim_df, milo_results, by="Nhood") 
+  viz_df[is.na(viz_df["nhIndex"]),'nhIndex'] <- 1:ncol(x) # Add index also to single-cells
   
   if (!is.null(split_by)){
-    split_df <- data.frame(split_by=colData(milo)[,split_by])
+    split_df <- data.frame(split_by=colData(x)[,split_by])
     split_df[,"nhIndex"] <- 1:nrow(split_df)
-    viz2_df  <- left_join(viz2_df, split_df, by="nhIndex") 
+    viz_df  <- left_join(viz_df, split_df, by="nhIndex") 
   }
   
   ## Filter significant DA nhoods 
   if (!is.null(filter_alpha)) {
-    viz2_df <- mutate(viz2_df, logFC = ifelse(SpatialFDR > filter_alpha, NA, logFC)) 
+    if (filter_alpha > 0) {
+      viz_df <- mutate(viz_df, logFC = ifelse(SpatialFDR > filter_alpha, NA, logFC)) 
+    }
   }
   
   ## Plot 
   pl <-
-    ggplot(data = arrange(viz2_df, abs(logFC)),
+    ggplot(data = arrange(viz_df, abs(logFC)),
            aes(X, Y)) +
     geom_point(aes(color = ''), size = pt_size / 3, alpha = 0.5) +
     geom_point(
@@ -135,8 +142,8 @@ plotMiloReducedDim <- function(x, milo_results, reduced_dims="UMAP", filter_alph
       low = "blue",
       name = "log-FC"
     ) +
-    xlab(paste(reduced_dims, components[1], sep="_")) +
-    ylab(paste(reduced_dims, components[2], sep="_"))
+    xlab(paste(nhood_reduced_dims, components[1], sep="_")) +
+    ylab(paste(nhood_reduced_dims, components[2], sep="_"))
   
   if (!is.null(split_by)) {
     pl <- pl + facet_wrap(split_by~.)

--- a/R/plotNhoods.R
+++ b/R/plotNhoods.R
@@ -38,7 +38,7 @@ plotNhoodSizeHist <- function(milo, bins=50){
   df <- data.frame(nh_size=sapply(nhoods(milo), function(x) length(x))) 
 
   ggplot(data=df, aes(nh_size)) + geom_histogram(bins=bins) +
-    xlab("Nhood size") +
+    xlab("Neighbourhood size") +
     theme_classic(base_size = 16)
 }
 

--- a/R/projectNeighbourhoodExpression.R
+++ b/R/projectNeighbourhoodExpression.R
@@ -24,7 +24,7 @@
 #' package \code{irlba} as in examples. The output of this function is used for visualization of test results.
 #'
 #' @return A \code{\linkS4class{matrix}} object of samples X reduced dimensions where samples are both
-#' the single-cells and the nhoods.
+#' the nhoods and the single-cells.
 #' (This will need to become a slot in Milo object)
 #' 
 #' @author
@@ -87,25 +87,11 @@ projectNhoodExpression <- function(x, d = 30, reduced_dims = "PCA", scale=TRUE){
   rownames(n.reducedDim) <-
     paste0("nh_", seq(1:nrow(n.reducedDim)))
   X_reduced_dims_merged <- rbind(n.reducedDim, X_reduced_dims)
-  ## --> this will need to be added as a slot in the Milo object
-  return(X_reduced_dims_merged)  
+  
+  ## Add to slot nhoodsReducedDim
+  nhoodReducedDim(x) <- list(X_reduced_dims_merged)
+  names(nhoodReducedDim(x)) <- reduced_dims
+  return(x)  
 }
 
-#' Calculates the l2-norm of a vector
-#'
-#' Adapted from PMA package
-#' @references Witten, Tibshirani, and Hastie, Biostatistics 2009
-#' @references \url{https://github.com/cran/PMA/blob/master/R/PMD.R}
-#'
-#' @param vec numeric vector
-#'
-#' @return returns the l2-norm.
-#'
-.l2norm <- function(vec) {
-  a <- sqrt(x = sum(vec ^ 2))
-  if (a == 0) {
-    a <- .05
-  }
-  return(a)
-}
 

--- a/R/projectNeighbourhoodExpression.R
+++ b/R/projectNeighbourhoodExpression.R
@@ -69,7 +69,7 @@ projectNhoodExpression <- function(x, d = 30, reduced_dims = "PCA", scale=TRUE){
   }
   
   ## Calculate mean profile of cells in a nhood
-  if (is.null(nhoodExpression(sim_milo))) {
+  if (is.null(nhoodExpression(x))) {
     x <- calcNhoodExpression(x, assay = "logcounts")
   }
   


### PR DESCRIPTION
I have added a new slot to the `Milo` object called `nhoodReducedDim`. This stores a named list where each element is a joint embedding between neighbourhoods and cells e.g. PCA, UMAP. What I am missing is a getter function that allows to call one element of the list: if I want to extract the PCA now I have to run `nhoodReducedDim(x)[["PCA"]]`, while I would want to use `nhoodReducedDim(x, "PCA")`. If you know how to do this please fire away, otherwise I can dig a bit deeper to figure it out. 

I haven't added a function to actually run the UMAP, because, as we discussed yesterday, each user should then do the embedding they prefer on the nhoods and cells, store it as `nhoodReducedDim` object and use the plotting function to visualize results.

