### PR TITLE
add neighbourhood subsetting to findNhoodMarkers

### DIFF
--- a/R/findNhoodMarkers.R
+++ b/R/findNhoodMarkers.R
@@ -30,6 +30,8 @@
 #' @param return.groups A logical scalar that returns a \code{\link{data.frame}} of the
 #' aggregated groups per single-cell. Cells that are members of non-DA neighbourhoods contain
 #' \code{NA} values.
+#' @param subset.nhoods A logical, integer or character vector indicating which neighbourhoods
+#' to subset before aggregation and DGE testing.
 #'
 #'
 #' @details
@@ -96,7 +98,7 @@ NULL
 findNhoodMarkers <- function(x, da.res, da.fdr=0.1, assay="logcounts",
                              overlap=1, lfc.threshold=NULL, merge.discord=FALSE,
                              subset.row=NULL, gene.offset=TRUE,
-                             return.groups=FALSE){
+                             return.groups=FALSE, subset.nhoods=NULL){
     if(class(x) != "Milo"){
         stop("Unrecognised input type - must be of class Milo")
     }
@@ -107,7 +109,8 @@ findNhoodMarkers <- function(x, da.res, da.fdr=0.1, assay="logcounts",
     nhs.da.gr <- .group_nhoods_by_overlap(nhoods(x),
                                           da.res=da.res,
                                           is.da=da.res$SpatialFDR < da.fdr,
-                                          overlap=overlap) # returns a vector group values for each nhood
+                                          overlap=overlap,
+                                          subset.nhoods=subset.nhoods) # returns a vector group values for each nhood
     nhood.gr <- unique(nhs.da.gr)
     # perform DGE _within_ each group of cells using the input design matrix
     message(paste0("Nhoods aggregated into ", length(nhood.gr), " groups"))

--- a/R/testDiffExp.R
+++ b/R/testDiffExp.R
@@ -208,8 +208,23 @@ testDiffExp <- function(x, da.res, design, meta.data, da.fdr=0.1, model.contrast
 
 #' @importFrom igraph graph_from_adjacency_matrix components
 .group_nhoods_by_overlap <- function(nhs, da.res, is.da, overlap=1,
-                                     lfc.threshold=NULL, merge.discord=FALSE){
-    ll_names <- expand.grid(names(nhs), names(nhs))
+                                     lfc.threshold=NULL, merge.discord=FALSE,
+                                     subset.nhoods=NULL){
+    if(!is.null(subset.nhoods)){
+        if(class(subset.nhoods) %in% c("character", "logical", "numeric")){
+            ll_names <- expand.grid(names(nhs)[subset.nhoods], names(nhs)[subset.nhoods])
+            if(length(is.da) == length(names(nhs))){
+                is.da[subset.nhoods]
+            } else{
+                stop("Subsetting `is.da` vector length does not equal nhoods length")
+            }
+        } else{
+            stop(paste0("Incorrect subsetting vector provided:", class(subset.nhoods)))
+        }
+    } else{
+        ll_names <- expand.grid(names(nhs), names(nhs))
+    }
+
     lintersect <- sapply(1:nrow(ll_names), function(x) length(intersect(nhs[[ll_names[x,1]]], nhs[[ll_names[x,2]]])))
     ## Count as connected only nhoods with at least n shared cells
     lintersect_filt <- ifelse(lintersect < overlap, 0, lintersect)


### PR DESCRIPTION
pass `subset.nhoods` as a vector in ids, logical or indices to subset marker gene selection to specific neighbourhoods.