### PR TITLE
Faster build nhood graph for faster viz

### DIFF
--- a/R/buildNhoodGraph.R
+++ b/R/buildNhoodGraph.R
@@ -43,8 +43,12 @@ buildNhoodGraph <- function(x){
 #' @importFrom gtools permutations
 .build_nhood_adjacency <- function(nhoods){
   nms <- permutations(n = length(nhoods), v = names(nhoods), r = 2, repeats.allowed = T)
+  keep_pairs <- sapply( 1:nrow(nms) , function(x) any(nhoods[[nms[x,1]]] %in% nhoods[[ nms[x,2] ]]))
   print("Calculating nhood adjacency....")
-  out <- sapply( 1:nrow(nms) , function(x) length( intersect( nhoods[[nms[x,1]]], nhoods[[ nms[x,2] ]]) ) )
+  pairs_int <- sapply( which(keep_pairs), function(x) length( intersect( nhoods[[nms[x,1]]], nhoods[[ nms[x,2] ]]) ) ) 
+  out <- rep(0, nrow(nms))
+  out[which(keep_pairs)] <- pairs_int
+
   nh_intersect_mat <- matrix(out, nrow = length(nhoods), byrow = TRUE)
   rownames(nh_intersect_mat) <- unique(nms[,1])
   colnames(nh_intersect_mat) <- unique(nms[,2])

--- a/R/buildNhoodGraph.R
+++ b/R/buildNhoodGraph.R
@@ -55,7 +55,3 @@ buildNhoodGraph <- function(x){
   return(nh_intersect_mat)
 }
 
-# ## A little test
-# nh1 <- sample(names(nhoods))[1]
-# nh2 <- sample(names(nhoods))[1]
-# nh_intersect_mat[nh1, nh2] == length(intersect(nhoods(sim_milo)[[nh1]], nhoods(sim_milo)[[nh2]]))


### PR DESCRIPTION
Refactored `buildNhoodGraph` to make if faster: calculates number of overlapping cells just for pairs on nhoods with at least one common cell.

Old version:
```r
> system.time(milo_old <- buildNhoodGraph(milo))
[1] "Calculating nhood adjacency...."
   user  system elapsed 
 30.168   0.032  30.194 
```

New version:
```r
> system.time(milo_new <- buildNhoodGraph(milo))
[1] "Calculating nhood adjacency...."
   user  system elapsed 
 14.960   0.044  14.997 
```
The graph is the same:
```
> all(as_adjacency_matrix(nhoodGraph(milo_new)) == as_adjacency_matrix(nhoodGraph(milo_old)))
[1] TRUE
```