### PR TITLE
Trimmed graph

### DIFF
--- a/R/buildNhoodGraph.R
+++ b/R/buildNhoodGraph.R
@@ -5,6 +5,8 @@
 #'
 #' @param x A \code{\linkS4class{Milo}} object with a non-empty \code{nhoods}
 #' slot.
+#' @param overlap A numeric scalar that thresholds graph edges based on  the number
+#' of overlapping cells between neighbourhoods.
 #'
 #' @details
 #' This constructs a graph where nodes represent neighbourhoods and edges represent the number of overlapping
@@ -22,36 +24,45 @@
 #' @importFrom igraph graph.adjacency set_vertex_attr vertex.attributes
 #' @export
 #' @rdname buildNhoodGraph
-buildNhoodGraph <- function(x){
-  # are neighbourhoods calculated?
-  if(length(nhoods(x)) == 0){
+buildNhoodGraph <- function(x, overlap=1){
+
+    if(!is(x, "Milo")){
+      stop("Not a valid Milo object")
+    }
+
+    # are neighbourhoods calculated?
+    if(length(nhoods(x)) == 0){
     stop("No neighbourhoods found - run makeNhoods first")
-  }
-  ## Build adjacency matrix for nhoods
-  nh_intersect_mat <- .build_nhood_adjacency(nhoods(x))
-  ## Make igraph object
-  ig <- graph.adjacency(nh_intersect_mat, mode="undirected", weighted=TRUE)
-  nhood_sizes <- sapply(nhoods(x), length)
-  ig <- set_vertex_attr(ig, name = 'size', value = nhood_sizes[vertex.attributes(ig)$name])
-  ## Add to nhoodGraph slot in milo object
-  nhoodGraph(x) <- ig
-  return(x)
+    }
+
+    ## Build adjacency matrix for nhoods
+    nh_intersect_mat <- .build_nhood_adjacency(nhoods(x))
+
+    ## Make igraph object
+    ig <- graph.adjacency(nh_intersect_mat, mode="undirected", weighted=TRUE)
+    nhood_sizes <- sapply(nhoods(x), length)
+    ig <- set_vertex_attr(ig, name = 'size', value = nhood_sizes[vertex.attributes(ig)$name])
+    ## Add to nhoodGraph slot in milo object
+    nhoodGraph(x) <- ig
+    return(x)
 }
 
 
 # Build adjacency matrix of overlap between neighbourhoods
 #' @importFrom gtools permutations
-.build_nhood_adjacency <- function(nhoods){
-  nms <- permutations(n = length(nhoods), v = names(nhoods), r = 2, repeats.allowed = TRUE)
-  keep_pairs <- sapply( 1:nrow(nms) , function(x) any(nhoods[[nms[x,1]]] %in% nhoods[[ nms[x,2] ]]))
-  print("Calculating nhood adjacency....")
-  pairs_int <- sapply( which(keep_pairs), function(x) length( intersect( nhoods[[nms[x,1]]], nhoods[[ nms[x,2] ]]) ) )
-  out <- rep(0, nrow(nms))
-  out[which(keep_pairs)] <- pairs_int
+.build_nhood_adjacency <- function(nhoods, overlap=1){
+    nms <- permutations(n = length(nhoods), v = names(nhoods), r = 2, repeats.allowed = TRUE)
+    # keep_pairs <- sapply( 1:nrow(nms) , function(x) any(nhoods[[nms[x,1]]] %in% nhoods[[ nms[x,2] ]]))
+    keep_pairs <- sapply( 1:nrow(nms), function(x) sum(nhoods[[nms[x,1]]] %in% nhoods[[ nms[x,2] ]]) > overlap)
 
-  nh_intersect_mat <- matrix(out, nrow = length(nhoods), byrow = TRUE)
-  rownames(nh_intersect_mat) <- unique(nms[,1])
-  colnames(nh_intersect_mat) <- unique(nms[,2])
-  return(nh_intersect_mat)
+    message("Calculating nhood adjacency")
+    pairs_int <- sapply( which(keep_pairs), function(x) length( intersect( nhoods[[nms[x,1]]], nhoods[[ nms[x,2] ]]) ) )
+    out <- rep(0, nrow(nms))
+    out[which(keep_pairs)] <- pairs_int
+
+    nh_intersect_mat <- matrix(out, nrow = length(nhoods), byrow = TRUE)
+    rownames(nh_intersect_mat) <- unique(nms[,1])
+    colnames(nh_intersect_mat) <- unique(nms[,2])
+    return(nh_intersect_mat)
 }
 

--- a/tests/testthat/test_buildGraph.R
+++ b/tests/testthat/test_buildGraph.R
@@ -8,7 +8,6 @@ library(scater)
 library(irlba)
 library(MASS)
 library(mvtnorm)
-library(miloR)
 
 set.seed(42)
 r.n <- 1000

--- a/tests/testthat/test_buildNhoodGraph.R
+++ b/tests/testthat/test_buildNhoodGraph.R
@@ -1,0 +1,81 @@
+context("Testing buildNhoodGraph function")
+library(miloR)
+
+### Set up a mock data set using simulated data
+library(SingleCellExperiment)
+library(scran)
+library(scater)
+library(dplyr)
+library(patchwork)
+
+data("sim_trajectory", package = "miloR")
+
+## Extract SingleCellExperiment object
+traj_sce <- sim_trajectory[['SCE']]
+
+## Extract sample metadata to use for testing
+traj_meta <- sim_trajectory[["meta"]]
+
+## Add metadata to colData slot
+colData(traj_sce) <- DataFrame(traj_meta)
+logcounts(traj_sce) <- log(counts(traj_sce) + 1)
+traj_sce <- runPCA(traj_sce, ncomponents=30)
+traj_sce <- runUMAP(traj_sce)
+traj_milo <- Milo(traj_sce)
+reducedDim(traj_milo, "UMAP") <- reducedDim(traj_sce, "UMAP")
+
+traj_milo <- buildGraph(traj_milo, k = 10, d = 30)
+
+test_that("Expected errors on missing input", {
+    expect_error(buildNhoodGraph(traj_milo),
+                 "No neighbourhoods found")
+
+    expect_error(buildNhoodGraph(traj_sce),
+                 "Not a valid Milo object")
+})
+
+test_that("Code produced identical output", {
+    library(igraph)
+    overlap <- 1
+    traj_milo <- makeNhoods(traj_milo, prop = 0.1, k = 10, d=30, refined = TRUE)
+    real.graph <- nhoodGraph(buildNhoodGraph(traj_milo, overlap=overlap))
+
+    ## Build adjacency matrix for nhoods
+    nhoods <- nhoods(traj_milo)
+
+    ## Make igraph object
+    nms <- permutations(n = length(nhoods), v = names(nhoods), r = 2, repeats.allowed = TRUE)
+    # keep_pairs <- sapply( 1:nrow(nms) , function(x) any(nhoods[[nms[x,1]]] %in% nhoods[[ nms[x,2] ]]))
+    keep_pairs <- sapply( 1:nrow(nms), function(x) sum(nhoods[[nms[x,1]]] %in% nhoods[[ nms[x,2] ]]) > overlap)
+
+    message("Calculating nhood adjacency....")
+    pairs_int <- sapply( which(keep_pairs), function(x) length( intersect( nhoods[[nms[x,1]]], nhoods[[ nms[x,2] ]]) ) )
+    out <- rep(0, nrow(nms))
+    out[which(keep_pairs)] <- pairs_int
+
+    nh_intersect_mat <- matrix(out, nrow = length(nhoods), byrow = TRUE)
+    rownames(nh_intersect_mat) <- unique(nms[,1])
+    colnames(nh_intersect_mat) <- unique(nms[,2])
+
+    ig <- graph.adjacency(nh_intersect_mat, mode="undirected", weighted=TRUE)
+    nhood_sizes <- sapply(nhoods(traj_milo), length)
+    ig <- set_vertex_attr(ig, name = 'size', value = nhood_sizes[vertex.attributes(ig)$name])
+
+    expect_true(is_igraph(real.graph))
+    expect_true(is_igraph(ig))
+
+    expect_equal(length(V(ig)), length(V(real.graph)))
+    expect_equal(length(E(ig)), length(E(real.graph)))
+
+    expect_equal(length(V(intersection(ig, real.graph))), length(V(real.graph)))
+    expect_equal(length(E(difference(ig, real.graph))), 0)
+})
+
+test_that("Overlap reduces edge connections", {
+    traj_milo <- makeNhoods(traj_milo, prop = 0.3, k = 10, d=30, refined = TRUE)
+
+    full.graph <- nhoodGraph(buildNhoodGraph(traj_milo, overlap=overlap))
+    sub.graph <- nhoodGraph(buildNhoodGraph(traj_milo, overlap=1500))
+})
+
+


### PR DESCRIPTION
Adding an `overlap` argument to `buildNhoodGraph` to only build edges between neighbourhoods with `overlap` shared vertices.